### PR TITLE
fix : DatePicker 초기값 및 선택불가 날짜 추가

### DIFF
--- a/src/widgets/date-picker/model/type.ts
+++ b/src/widgets/date-picker/model/type.ts
@@ -1,4 +1,5 @@
 export interface DatePickerProps {
     initialDate?: Date;
+    disabledDates?: string[];
     onSelectDate: (date: Date) => void;
 }

--- a/src/widgets/date-picker/ui/DatePicker.stories.ts
+++ b/src/widgets/date-picker/ui/DatePicker.stories.ts
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof DatePicker>;
 
 export const Default: Story = {
     args: {
-        initialDate: new Date(), // 오늘 날짜로 초기화
         onSelectDate: (date) => console.log('선택된 날짜:', date)
     }
 };

--- a/src/widgets/date-picker/ui/DatePicker.tsx
+++ b/src/widgets/date-picker/ui/DatePicker.tsx
@@ -8,9 +8,11 @@ import {
 } from './DatePicker.styled'; // 스타일드 컴포넌트 불러오기
 import moment from 'moment';
 import { DatePickerProps } from '../model/type';
+import { setDateFormat } from './setDateFormat';
 
 export const DatePicker: React.FC<DatePickerProps> = ({
     initialDate,
+    disabledDates = [],
     onSelectDate
 }) => {
     const [selectedDate, setSelectedDate] = useState<Date | null>(
@@ -42,6 +44,14 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         setIsModalOpen((prev) => !prev);
     };
 
+    const isDateDisabled = (date: Date) => {
+        const formattedDate = setDateFormat(date); // 문자열 형식으로 변환
+        return (
+            date > today || // 오늘 이후 날짜 비활성화
+            disabledDates.includes(formattedDate) // 비활성화할 날짜 배열에 포함된 경우
+        );
+    };
+
     return (
         <StyledCalendarWrapper>
             <StyledButton onClick={toggleModal}>
@@ -54,6 +64,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                     locale="ko-KR"
                     calendarType="gregory"
                     maxDate={today} // 오늘 이후 날짜 선택 불가
+                    tileDisabled={({ date }) => isDateDisabled(date)} // 비활성화 날짜
                     formatDay={(locale, date) => moment(date).format('D')} // 일 제거 숫자만 보이게
                     formatYear={(locale, date) => moment(date).format('YYYY')} // 네비게이션 눌렀을때 숫자 년도만 보이게
                     formatMonthYear={(locale, date) =>
@@ -77,6 +88,14 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                                     selectedDate.toDateString()
                             ) {
                                 classNames = 'selected'; // 선택된 날짜
+                            }
+                            if (
+                                disabledDates.some(
+                                    (disabledDate) =>
+                                        disabledDate === setDateFormat(date)
+                                )
+                            ) {
+                                classNames = 'disabled'; // @ 비활성화 날짜 스타일 적용
                             }
                         }
                         return classNames;

--- a/src/widgets/date-picker/ui/setDateFormat.ts
+++ b/src/widgets/date-picker/ui/setDateFormat.ts
@@ -1,0 +1,3 @@
+export function setDateFormat(date: Date) {
+    return `${date.getFullYear()}. ${String(date.getMonth() + 1).padStart(2, '0')}. ${String(date.getDate()).padStart(2, '0')}`;
+}

--- a/src/widgets/write-diary/model/type.ts
+++ b/src/widgets/write-diary/model/type.ts
@@ -1,9 +1,12 @@
 export interface WriteDiaryContainerProps {
-    onDiarySubmit: (data: {
+    initialDate?: Date;
+    initialTitle?: string;
+    initialContent?: string;
+    initialIsPublic?: boolean;
+    onDiarySubmit: (diaryData: {
         selectedDate: Date;
         title: string;
         content: string;
         isPublic: boolean;
     }) => void;
-    initialDate?: Date;
 }

--- a/src/widgets/write-diary/ui/WriteDiaryContainer.stories.ts
+++ b/src/widgets/write-diary/ui/WriteDiaryContainer.stories.ts
@@ -12,8 +12,19 @@ type Story = StoryObj<typeof WriteDiaryContainer>;
 
 export const Default: Story = {
     args: {
-        // onDiarySubmit: (e) => {
-        //     console.log(e);
-        // }
+        onDiarySubmit: (diaryData) => {
+            console.log(diaryData); // 다이어리 데이터가 제출될 때 콘솔에 출력
+        },
+        initialDate: new Date('2024 10 11')
+    }
+};
+
+export const Editing: Story = {
+    args: {
+        onDiarySubmit: (diaryData) => {
+            console.log(diaryData); // 다이어리 데이터가 제출될 때 콘솔에 출력
+        },
+        initialDate: new Date()
+        // initialDate: new Date('2024 10 11')
     }
 };

--- a/src/widgets/write-diary/ui/WriteDiaryContainer.tsx
+++ b/src/widgets/write-diary/ui/WriteDiaryContainer.tsx
@@ -14,16 +14,50 @@ import InputForm from '@/shared/ui/InputForm/InputForm';
 import Button from '@/shared/ui/Button/Button';
 import { DatePicker } from '@/widgets/date-picker';
 import { DiaryVisibilityControls } from '@/widgets/diary-visibility-controls';
+import { setDateFormat } from '@/widgets/date-picker/ui/setDateFormat';
 
 export const WriteDiaryContainer: React.FC<WriteDiaryContainerProps> = ({
-    onDiarySubmit,
-    initialDate = new Date() // 초기 날짜가 없으면 오늘 날짜 사용
+    initialDate = new Date(), // 초기 날짜가 없으면 오늘 날짜 사용
+    initialTitle = '',
+    initialContent = '',
+    initialIsPublic = true,
+    onDiarySubmit
 }) => {
     const [selectedDate, setSelectedDate] = useState<Date>(initialDate);
-    const [title, setTitle] = useState('');
-    const [content, setContent] = useState('');
-    const [isPublic, setIsPublic] = useState(true);
+    const [title, setTitle] = useState(initialTitle);
+    const [content, setContent] = useState(initialContent);
+    const [isPublic, setIsPublic] = useState(initialIsPublic);
     const [isButtonActive, setIsButtonActive] = useState(false);
+
+    const [existingDiaryDates, setExistingDiaryDates] = useState<string[]>([]); // 일기 작성된 날짜 배열
+    const [isEditing, setIsEditing] = useState(false); // 일기 수정 페이지 인지, 초기 날짜(오늘)가 일기 작성된 날짜 배열에 있으면 일기 수정 페이지
+
+    const userEmail = 'perfectTest@naver.com'; // 샘플 계정
+
+    useEffect(() => {
+        const fetchDisabledDates = async () => {
+            try {
+                const response = await fetch(
+                    `https://td3axvf8x7.execute-api.ap-northeast-2.amazonaws.com/moodi/diary?limit=40&user_email=${userEmail}`
+                ); // @ API 호출
+                const data = await response.json();
+                const dates = data.diaries.map(
+                    (diary: { title_date: string | number | Date }) =>
+                        setDateFormat(new Date(diary.title_date)) // 'YYYY. MM. DD.' 형식으로 -> 다시 문자열 형태로
+                );
+
+                setExistingDiaryDates(dates);
+            } catch (error) {
+                console.error(error);
+            }
+        };
+
+        fetchDisabledDates(); // 비활성화 날짜 데이터 가져오기
+    }, []);
+
+    useEffect(() => {
+        setIsEditing(existingDiaryDates.includes(setDateFormat(initialDate)));
+    }, [existingDiaryDates, initialDate]);
 
     useEffect(() => {
         setIsButtonActive(title.trim() !== '' && content.trim() !== '');
@@ -50,13 +84,15 @@ export const WriteDiaryContainer: React.FC<WriteDiaryContainerProps> = ({
     return (
         <Container>
             <SelectDateContainer>
-                <DateContainer>
-                    {selectedDate
-                        ? selectedDate.toLocaleDateString()
-                        : '날짜를 선택하세요.'}
-                </DateContainer>
+                <DateContainer>{setDateFormat(selectedDate)}</DateContainer>
                 <DatePickeContainer>
-                    <DatePicker onSelectDate={handleDateSelect} />
+                    {isEditing ? null : (
+                        <DatePicker
+                            initialDate={selectedDate}
+                            onSelectDate={handleDateSelect}
+                            disabledDates={existingDiaryDates}
+                        />
+                    )}
                 </DatePickeContainer>
             </SelectDateContainer>
             <TitleContainer>
@@ -100,7 +136,6 @@ export const WriteDiaryContainer: React.FC<WriteDiaryContainerProps> = ({
                                 content,
                                 isPublic
                             });
-                            console.log(selectedDate, title, content, isPublic);
                         }
                     }}
                 >


### PR DESCRIPTION
# 🚀요약
DatePicker 초기값과 선택불가 날짜 추가
# 📸사진 (구현 캡처)

# 📝작업 내용

-   [x] 일기 작성과 수정 구별
api에서 받은 일기가 작성된 날짜로 일기 작성에서 초기 선택 날짜가 일기 작성 날짜에 존재한다면 일기 수정으로 판단
작성 날짜, 제목, 내용, 비공 여부를 초기값으로 받을 수 있도록 수정
- `initialDate`, `initialTitle`, `initialContent`, `initialIsPublic`

-   [x] DatePicker 선택 불가 날짜 추가
일기가 작성된 날짜를 DatePicker에서 받아 선택 불가 날짜를 지정
처음 선택된 값이 하이라이트 되도록 수정
- `initialDate`, `disabledDates`

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #이슈번호
