### PR TITLE
123 feat/일기 조회 페이지-메인 및 서브 감정 위젯

### DIFF
--- a/src/widgets/show-main-emotion/index.ts
+++ b/src/widgets/show-main-emotion/index.ts
@@ -1,0 +1,1 @@
+export { ShowMainEmotionContainer } from './ui/ShowMainEmotionContainer';

--- a/src/widgets/show-main-emotion/model/type.ts
+++ b/src/widgets/show-main-emotion/model/type.ts
@@ -1,0 +1,5 @@
+import { Emotions } from '@/shared/model/EmotionEnum';
+
+export interface ShowMainEmotionContainerProps {
+    emotion: Emotions;
+}

--- a/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.stories.ts
+++ b/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowMainEmotionContainer } from './ShowMainEmotionContainer';
+import { Emotions } from '@/shared/model/EmotionEnum';
+
+const meta: Meta<typeof ShowMainEmotionContainer> = {
+    title: 'Widgets/UI/ShowMainEmotionContainer',
+    component: ShowMainEmotionContainer,
+    tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof ShowMainEmotionContainer>;
+
+export const Default: Story = {
+    args: {
+        emotion: Emotions.Happy
+    }
+};

--- a/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.styles.ts
+++ b/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.styles.ts
@@ -9,10 +9,6 @@ export const Container = styled.div`
     padding: 30px;
     box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.13);
 
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
     font-size: 16px;
     font-weight: bold;
     font-family: 'Pretendard', sans-serif;
@@ -32,7 +28,7 @@ export const EmotionContainer = styled.div`
     padding: 20px;
     left: 50%;
     transform: translateX(-50%);
-    margin-top: 70px;
+    margin-top: 60px;
     gap: 10px;
 
     font-weight: normal;

--- a/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.styles.ts
+++ b/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.styles.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    // position: absolute;
+    // width: 100%;
+    height: 250px;
+    background-color: #ffffff;
+    border-radius: 10px;
+    padding: 30px;
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.13);
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    font-size: 16px;
+    font-weight: bold;
+    font-family: 'Pretendard', sans-serif;
+`;
+
+export const EmotionContainer = styled.div`
+    position: absolute;
+    display: flex;
+    height: 100px;
+    width: 70px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #ffffff;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 70px;
+    gap: 10px;
+
+    font-weight: normal;
+`;

--- a/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.tsx
+++ b/src/widgets/show-main-emotion/ui/ShowMainEmotionContainer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Container, EmotionContainer } from './ShowMainEmotionContainer.styles';
+import { ShowMainEmotionContainerProps } from '../model/type';
+import { EmotionIcon } from '@/shared/EmotionIcon/ui/EmotionIcon';
+import { getEmotionInfo } from '@/shared/model/EmotionEnum';
+
+export const ShowMainEmotionContainer = ({
+    emotion
+}: ShowMainEmotionContainerProps) => {
+    return (
+        <Container>
+            메인 감정 키워드
+            <EmotionContainer>
+                <EmotionIcon emotion={emotion} width="50px" height="50px" />
+                {getEmotionInfo(emotion).description}
+            </EmotionContainer>
+        </Container>
+    );
+};

--- a/src/widgets/show-sub-emotion/index.ts
+++ b/src/widgets/show-sub-emotion/index.ts
@@ -1,0 +1,1 @@
+export { ShowSubEmotionContainer } from './ui/ShowSubEmotionContainer';

--- a/src/widgets/show-sub-emotion/model/type.ts
+++ b/src/widgets/show-sub-emotion/model/type.ts
@@ -1,0 +1,5 @@
+import { Emotions } from '@/shared/model/EmotionEnum';
+
+export interface ShowSubEmotionContainerProps {
+    subEmotions: Emotions[];
+}

--- a/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.stories.ts
+++ b/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowSubEmotionContainer } from './ShowSubEmotionContainer';
+import { Emotions } from '@/shared/model/EmotionEnum';
+
+const meta: Meta<typeof ShowSubEmotionContainer> = {
+    title: 'Widgets/UI/ShowSubEmotionContainer',
+    component: ShowSubEmotionContainer,
+    tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof ShowSubEmotionContainer>;
+
+export const Default: Story = {
+    args: {
+        subEmotions: [
+            Emotions.Angry,
+            Emotions.Sad,
+            Emotions.Blank,
+            Emotions.Excited
+        ]
+    }
+};

--- a/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.styled.ts
+++ b/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.styled.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    // position: absolute;
+    // width: 100%;
+    height: 250px;
+    background-color: #ffffff;
+    border-radius: 10px;
+    padding: 30px;
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.13);
+
+    font-size: 16px;
+    font-weight: bold;
+    font-family: 'Pretendard', sans-serif;
+`;
+export const EmotionsContainer = styled.div`
+    margin-top: 70px;
+
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+`;
+
+export const EmotionContainer = styled.div`
+    display: flex;
+    height: 30px;
+    // width: 100px;
+    align-items: center;
+    justify-content: center;
+    background-color: #ffffff;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 10px 20px;
+    gap: 10px;
+
+    font-weight: normal;
+    font-size: 14px;
+`;

--- a/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.styled.ts
+++ b/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.styled.ts
@@ -14,7 +14,7 @@ export const Container = styled.div`
     font-family: 'Pretendard', sans-serif;
 `;
 export const EmotionsContainer = styled.div`
-    margin-top: 70px;
+    margin-top: 60px;
 
     display: flex;
     flex-wrap: wrap;

--- a/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.tsx
+++ b/src/widgets/show-sub-emotion/ui/ShowSubEmotionContainer.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+    Container,
+    EmotionContainer,
+    EmotionsContainer
+} from './ShowSubEmotionContainer.styled';
+import { ShowSubEmotionContainerProps } from '../model/type';
+import { EmotionIcon } from '@/shared/EmotionIcon/ui/EmotionIcon';
+import { getEmotionInfo } from '@/shared/model/EmotionEnum';
+
+export const ShowSubEmotionContainer = ({
+    subEmotions
+}: ShowSubEmotionContainerProps) => {
+    return (
+        <Container>
+            서브 감정 키워드
+            <EmotionsContainer>
+                {subEmotions.map((emotion) => {
+                    return (
+                        <EmotionContainer>
+                            <EmotionIcon
+                                emotion={emotion}
+                                width="25px"
+                                height="25px"
+                            />
+                            {getEmotionInfo(emotion).description}
+                        </EmotionContainer>
+                    );
+                })}
+            </EmotionsContainer>
+        </Container>
+    );
+};


### PR DESCRIPTION
# 🚀요약
일기 조회 페이지의 메인 및 서브 감정 위젯 구현
# 📸사진 (구현 캡처)
![2024-11-04 15 58 12](https://github.com/user-attachments/assets/66d6f966-ee8c-40a7-b625-02ed4885a78e)
![2024-11-04 15 58 41](https://github.com/user-attachments/assets/0796c915-34e8-42c6-a55e-5e0388c74a20)

# 📝작업 내용
- 메인 감정 위젯은 Emotions 타입의 `emotion`
- 서브 감정 위젯은 Emotions 타입을 담은 배열 `subEmotions`

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #123
