### PR TITLE
feat : 일기 조회 페이지 - 음악 위젯 구현

### DIFF
--- a/src/widgets/show-music/index.ts
+++ b/src/widgets/show-music/index.ts
@@ -1,0 +1,1 @@
+export { ShowMusicContainer } from './ui/ShowMusicContainer';

--- a/src/widgets/show-music/model/type.ts
+++ b/src/widgets/show-music/model/type.ts
@@ -1,0 +1,6 @@
+export interface ShowMusicContainerProps {
+    youtubeId: string; // 유튜브 ID
+    thumbnailUrl: string; // 스포티파이 썸네일
+    title: string; // 곡 제목
+    artist: string; // 곡 아티스트
+}

--- a/src/widgets/show-music/ui/ShowMusicContainer.stories.ts
+++ b/src/widgets/show-music/ui/ShowMusicContainer.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowMusicContainer } from './ShowMusicContainer';
+
+const meta: Meta<typeof ShowMusicContainer> = {
+    title: 'Widgets/UI/ShowMusicContainer',
+    component: ShowMusicContainer,
+    tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof ShowMusicContainer>;
+
+export const Default: Story = {
+    args: {
+        youtubeId: 'ArmDp-zijuc',
+        thumbnailUrl:
+            'https://i.scdn.co/image/ab67616d0000b2730744690248ef3ba7b776ea7b',
+        title: 'Super Shy',
+        artist: 'NewJeans'
+    }
+};

--- a/src/widgets/show-music/ui/ShowMusicContainer.styled.ts
+++ b/src/widgets/show-music/ui/ShowMusicContainer.styled.ts
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+// import { Container as MusicCard } from '@/entities/music/ui/MusicCard.styled';
+
+export const Container = styled.div`
+    background-color: #ffffff;
+    border-radius: 10px;
+    padding: 30px;
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.13);
+
+    font-size: 16px;
+    font-weight: bold;
+    font-family: 'Pretendard', sans-serif;
+`;
+
+export const HiddenYoutubeContainer = styled.div`
+    position: fixed;
+    top: -9999px;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    visibility: hidden;
+`;
+
+export const SubContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 30px;
+    margin-top: 10px;
+    margin-bottom: 50px;
+`;
+
+// export const MusicCardContainer = styled(MusicCard)`
+//     &:hover {
+//         background-color: #ffffff;
+//     }
+// `;

--- a/src/widgets/show-music/ui/ShowMusicContainer.tsx
+++ b/src/widgets/show-music/ui/ShowMusicContainer.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import {
+    Container,
+    SubContainer,
+    HiddenYoutubeContainer
+} from './ShowMusicContainer.styled';
+import { ShowMusicContainerProps } from '../model/type';
+import { MusicCard } from '@/entities/music';
+import { YoutubeButton } from './YoutubeButton';
+
+export const ShowMusicContainer = ({
+    youtubeId,
+    thumbnailUrl,
+    title,
+    artist
+}: ShowMusicContainerProps) => {
+    const [nowPlaying, setNowPaying] = useState<string | null>(null);
+
+    const handlePlay = (id: string) => {
+        if (nowPlaying === id) {
+            setNowPaying(null);
+            console.log('노래 재생 중지');
+        } else {
+            setNowPaying(id);
+            console.log('노래 재생 중 : ', id);
+        }
+    };
+
+    return (
+        <Container>
+            노래
+            <SubContainer>
+                <HiddenYoutubeContainer>
+                    {nowPlaying && (
+                        <iframe
+                            title="YouTube music player"
+                            width="560"
+                            height="315"
+                            src={`https://www.youtube.com/embed/${youtubeId}?autoplay=1`}
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowFullScreen
+                        />
+                    )}
+                </HiddenYoutubeContainer>
+                <MusicCard
+                    youtubeId={youtubeId}
+                    thumbnailUrl={thumbnailUrl}
+                    title={title}
+                    artist={artist}
+                    $isPlaying={nowPlaying === youtubeId}
+                    onPlay={handlePlay}
+                    onClick={() => {}}
+                />
+                <YoutubeButton
+                    youtubeUrl={`https://www.youtube.com/watch?v=${youtubeId}`}
+                />
+            </SubContainer>
+        </Container>
+    );
+};

--- a/src/widgets/show-music/ui/YoutubeButton.styled.ts
+++ b/src/widgets/show-music/ui/YoutubeButton.styled.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const YoutubeButtonContainer = styled.a`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 180px;
+    height: 50px;
+    background-color: #d80700;
+    border-radius: 10px;
+    cursor: pointer;
+    text-decoration: none;
+
+    color: #ffffff;
+    font-weight: normal;
+
+    &:hover {
+        background-color: #b80600;
+    }
+`;

--- a/src/widgets/show-music/ui/YoutubeButton.tsx
+++ b/src/widgets/show-music/ui/YoutubeButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { YoutubeButtonContainer } from './YoutubeButton.styled';
+
+interface YoutubeButtonProps {
+    youtubeUrl: string;
+}
+
+export const YoutubeButton = ({ youtubeUrl }: YoutubeButtonProps) => {
+    return (
+        <YoutubeButtonContainer
+            href={youtubeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            Youtube 바로가기
+        </YoutubeButtonContainer>
+    );
+};


### PR DESCRIPTION
# 🚀요약
일기 조회 페이지의 음악 위젯 구현
# 📸사진 (구현 캡처)
![2024-11-05 12 05 22](https://github.com/user-attachments/assets/eb046958-109f-497d-8a4c-ecd59020fa76)

# 📝작업 내용
- `youtubeId` : 유튜브 아이디
- `thumbnailUrl` : 노래 썸네일 url
- `title` : 노래 제목
- `artist` : 노래 가수

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #155
