### PR TITLE
fix : ReactSelector컴포넌트 - '일기 불러오기 실패' 오류 수정 

### DIFF
--- a/src/entities/ReactionButtonContainer/ui/ReactionButtonContainer.styled.ts
+++ b/src/entities/ReactionButtonContainer/ui/ReactionButtonContainer.styled.ts
@@ -1,14 +1,18 @@
 import theme from '@/app/styles/theme';
 import styled from 'styled-components';
 
+interface StyledReactionBtnContainerProps {
+    align?: string;
+}
+
 export const StyledReactionContainer = styled.div`
-    width: 40%;
+    width: 100%;
 `;
 
-export const StyledReactionBtnContainer = styled.div`
+export const StyledReactionBtnContainer = styled.div<StyledReactionBtnContainerProps>`
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    justify-content: ${(props) => props.align || 'center'}; // align prop을 적용
     width: 100%;
 
     & > button {

--- a/src/entities/ReactionButtonContainer/ui/ReactionButtonContainer.tsx
+++ b/src/entities/ReactionButtonContainer/ui/ReactionButtonContainer.tsx
@@ -14,22 +14,24 @@ import { Reaction } from '../model/reaction';
 
 interface ReactionListProps {
     reactions: Reaction[];
-    isHorizontal: boolean;
-    isAddBtnVisible: boolean;
+    isHorizontal?: boolean;
+    isAddBtnVisible?: boolean;
     onReactionUpdate: (
         emotion: Emotions,
         count: number,
         isAlreadyClicked: boolean
     ) => void;
     onSelectedEmotionsChange: (selectedEmotions: Emotions[]) => void;
+    align?: string;
 }
 
 const ReactionButtonContainer: React.FC<ReactionListProps> = ({
     reactions = [],
-    isHorizontal,
+    isHorizontal = true,
     isAddBtnVisible = false,
     onReactionUpdate,
-    onSelectedEmotionsChange
+    onSelectedEmotionsChange,
+    align = 'left' // left, center, right
 }) => {
     const [clickedEmotions, setClickedEmotions] = useState<Emotions[]>([]);
     const [updatedReactions, setUpdatedReactions] =
@@ -90,7 +92,7 @@ const ReactionButtonContainer: React.FC<ReactionListProps> = ({
 
     return (
         <StyledReactionContainer>
-            <StyledReactionBtnContainer>
+            <StyledReactionBtnContainer align={align}>
                 {updatedReactions.map(({ emotion, reactionCnt }) => (
                     <ReactionButton
                         key={emotion}

--- a/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBox.tsx
+++ b/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBox.tsx
@@ -46,7 +46,7 @@ const ContentBox: React.FC<ContentBoxProps> = ({
         timeAgo = `${diffInMinutes}분전`;
     }
     const token =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im1pbmpvb24iLCJlbWFpbCI6ImFubmF3YTZAbmF2ZXIuY29tLmNvbSIsImlhdCI6MTczMDc5MzYwMywiZXhwIjoxNzMwODA0NDAzfQ.Rr6DsZb7MPkOeDVelLpkZxGDB0FRDfFVBryrQliuN8g';
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6IuyCrOyaqeyekDIiLCJlbWFpbCI6InVzZXIyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzMwODI0NDI0LCJleHAiOjE3MzA4MzUyMjR9.iGY1f5Uh0bsKa_nJuVy72YeH-bYF_MK3l6VQQwAP3XE';
 
     return (
         <Wrapper>
@@ -60,8 +60,8 @@ const ContentBox: React.FC<ContentBoxProps> = ({
                 <Reaction>
                     <ReactionSelector
                         diaryId={id}
-                        userEmail="annawa6@naver.com.com"
-                        isHorizontal={false}
+                        userEmail="user2@example.com"
+                        isHorizontal
                         isAddBtnVisible={false}
                         token={token}
                     />

--- a/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBoxCss.ts
+++ b/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBoxCss.ts
@@ -44,9 +44,7 @@ export const Time = styled.div`
 `;
 
 export const Reaction = styled.div`
-    width: 200px;
-    height: 30px;
-    border: 1px solid black;
+    width: 100%;
 `;
 
 export const Emotion = styled.div<{ imgPath: string | null }>`

--- a/src/widgets/reaction-selector/ui/ReactionSelector.tsx
+++ b/src/widgets/reaction-selector/ui/ReactionSelector.tsx
@@ -24,6 +24,7 @@ interface ReactBtnProps {
     isHorizontal: boolean;
     isAddBtnVisible: boolean;
     token: string;
+    align?: string;
 }
 
 const ReactionSelector = ({
@@ -31,11 +32,11 @@ const ReactionSelector = ({
     userEmail,
     isHorizontal,
     isAddBtnVisible,
-    token
+    token,
+    align = 'left' // (ex) left, center, right
 }: ReactBtnProps) => {
     const [diary, setDiary] = useState<DiaryType | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<string | null>(null);
     const [reactions, setReactions] = useState<ReactionList[]>([]);
     const [previousEmotions, setPreviousEmotions] = useState<Emotions[]>([]);
 
@@ -141,11 +142,11 @@ const ReactionSelector = ({
             if (data) {
                 setDiary(data);
                 processReactions(data.reactions);
-            } else {
-                setError('일기를 불러오는 데 실패했습니다.');
             }
         } catch (e) {
-            setError('일기를 불러오는 데 실패했습니다.');
+            console.log(
+                `ReactionSelectorError : 일기를 불러오는데 실패했습니다. ${e}`
+            );
         } finally {
             setLoading(false);
         }
@@ -177,7 +178,6 @@ const ReactionSelector = ({
     const memoizedReactions = useMemo(() => {
         return reactions.map((reaction) => ({
             ...reaction
-            // 필요한 추가 데이터 처리
         }));
     }, [reactions]);
 
@@ -185,14 +185,11 @@ const ReactionSelector = ({
         return null;
     }
 
-    if (error) {
-        return <div>{error}</div>;
-    }
-
     const args = {
         isHorizontal,
         isAddBtnVisible,
         reactions: memoizedReactions,
+        align,
         onReactionUpdate: async (
             emotion: Emotions,
             count: number,
@@ -214,13 +211,8 @@ const ReactionSelector = ({
                             id: selectedReaction.reaction_id,
                             token
                         });
-                        console.log('Reaction deleted successfully');
                         await getDiaryData();
-                    } else {
-                        console.log('No selected reaction found.');
                     }
-                } else {
-                    console.log('Diary data is not available.');
                 }
             } else {
                 await handlePostReaction({
@@ -241,6 +233,7 @@ const ReactionSelector = ({
                 isAddBtnVisible={isAddBtnVisible}
                 onReactionUpdate={args.onReactionUpdate}
                 onSelectedEmotionsChange={handleSelectedEmotions}
+                align={args.align}
             />
         </StyledReactionSelector>
     );


### PR DESCRIPTION
# 🚀요약
타임라인 컴포넌트에 Reaction 버튼 컴포넌트를 삽입했을 때, '일기 불러오기 실패' 문구가 출력되는 오류 수정

# 📸사진 (구현 캡처)
<img width="771" alt="image" src="https://github.com/user-attachments/assets/b03de3f8-5417-47aa-a997-5fb382211a80">

# 📝작업 내용
-   [x] 일기 데이터가 없을 때, 에러를 출력하도록 하는 코드 삭제 
-   [x] 테스트용 email, token을 활용해서 불러올수 있도록 임시 설정함
-   [x] ReactionSelector 컴포넌트 props 추가 ( align : left/center/right 선택) 

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
close #184  
