### PR TITLE
fix : 타임라인에 포함된 ReactionSelector 컴포넌트 버튼 안눌림 오류 수정

### DIFF
--- a/src/widgets/reaction-selector/ui/ReactionSelector.tsx
+++ b/src/widgets/reaction-selector/ui/ReactionSelector.tsx
@@ -40,6 +40,8 @@ const ReactionSelector = ({
     const [reactions, setReactions] = useState<ReactionList[]>([]);
     const [previousEmotions, setPreviousEmotions] = useState<Emotions[]>([]);
 
+    const apiToken = token.replace(/"/g, '');
+
     const updateReactions = async (selectedEmotions: Emotions[]) => {
         const updatedReactions = [...reactions];
 
@@ -82,7 +84,7 @@ const ReactionSelector = ({
                     const selectedReaction = selectedReactions[0];
                     await deleteReaction({
                         id: selectedReaction.reaction_id,
-                        token
+                        token: apiToken
                     });
                 }
             }
@@ -164,7 +166,7 @@ const ReactionSelector = ({
         };
 
         try {
-            await postReaction(reaction, token);
+            await postReaction(reaction, apiToken);
             await getDiaryData();
         } catch (e) {
             console.error('Failed to post reaction:', e);
@@ -209,7 +211,7 @@ const ReactionSelector = ({
                         const selectedReaction = selectedReactions[0];
                         await deleteReaction({
                             id: selectedReaction.reaction_id,
-                            token
+                            token: apiToken
                         });
                         await getDiaryData();
                     }


### PR DESCRIPTION
# 🚀요약
ReactionSelector 컴포넌트는 token값을 props로 전달해야함.
이때 쌍따옴표가 포함된 경우, 제거하도록 방어코드 삽입

# 📸사진 (구현 캡처)

# 📝작업 내용
-   [ ] 쌍따옴표 제거 방어코드 삽입
-   [ ]

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #220 
