### PR TITLE
fix : 달력 및 리스트 반응형 수정

### DIFF
--- a/src/features/calendar/calendar-ui/calendarUiCss.ts
+++ b/src/features/calendar/calendar-ui/calendarUiCss.ts
@@ -31,6 +31,9 @@ export const StyledCalendar = styled(Calendar).attrs({
                 background-color: rgba(0, 0, 0, 0.05);
                 cursor: pointer;
             }
+            @media (max-width: 960px) {
+                display: none;
+            }
         }
 
         //년월텍스트
@@ -38,6 +41,7 @@ export const StyledCalendar = styled(Calendar).attrs({
             font-size: 1rem;
             border: 1px solid rgba(0, 0, 0, 0.1);
             margin: 0 1rem;
+            display: block !important;
         }
     }
 

--- a/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBoxCss.ts
+++ b/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBoxCss.ts
@@ -15,6 +15,10 @@ export const Box = styled.div<{ imgUrl: string }>`
     justify-content: center;
     align-items: end;
 
+    @media (max-width: 960px) {
+        width: 50px;
+    }
+
     &::after {
         content: '';
         display: block;
@@ -47,6 +51,7 @@ export const Box = styled.div<{ imgUrl: string }>`
         transition: 0.2s;
         font-size: 14px;
         padding-bottom: 8px;
+        text-align: center;
     }
 
     &:hover > p {


### PR DESCRIPTION
# 🚀요약
달력 및 리스트 반응형 수정
# 📸사진 (구현 캡처)

# 📝작업 내용
달력의 경우, 960px아래일때, 양쪽 arrow를 display none처리 함으로서 년월박스의 줄바꿈을 해결
리스트의 경우, 960px아래일 때, img의 width를 줄임으로서 content의 줄바꿈을 보완(많이 길면 어느정도는 줄바꿈을 감수함)
-   [ ]
-   [ ]

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #277 
